### PR TITLE
modified extractBestPreds to handle NAs present in adaptive_cv

### DIFF
--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -55,17 +55,19 @@ extractBestPreds <- function(list_of_models){
   #TODO: add an optional progress bar?
   #Extract resampled predictions from each model
   modelLibrary <- lapply(list_of_models, function(x) {x$pred})
-
+  
   #Extract the best tuning parameters from each model
   tunes <- lapply(list_of_models, function(x) {x$bestTune})
-
+  
   #Subset the resampled predictions to the model with the best tune and sort
   newModels <- lapply(1:length(modelLibrary), function(x) NA)
   for (i in 1:length(modelLibrary)){
     out <- modelLibrary[[i]]
     tune <- tunes[[i]]
     for (name in names(tune)){
-      out <- out[out[,name]==tune[,name],]
+      indxLogic <- out[,name]==tune[,name]
+      indxLogic[is.na(indxLogic)] <- FALSE
+      out <- out[indxLogic,]
     }
     out <- out[order(out$Resample, out$rowIndex),]
     newModels[[i]] <- out


### PR DESCRIPTION
This fixes #94.  Tested it with boot, cv, and adaptive_cv. Identical outputs on boot and cv, and now returns valid results with no NAs using adaptive_cv.
