### PR TITLE
Run tests twice, and make warnings errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 # Sample .travis.yml for R projects from https://github.com/craigcitro/r-travis
+# https://github.com/craigcitro/r-travis/wiki
 
 language: c
 
 env:
    global:
+     - WARNINGS_ARE_ERRORS=1
      - R_BUILD_ARGS=" "
      - R_CHECK_ARGS="--as-cran"
      - BOOTSTRAP_LATEX="1"
+   matrix:
+     - NOT_CRAN="true"
+     - NOT_CRAN="false"
 
 before_install:
   - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh


### PR DESCRIPTION
- First test runs all skip_on_cran() test
- Second test runs exactly as cran, and skips them.
- Warnings are now errors and cause a travis failure.  I wonder if I
  can makes NOTES errors as well?

Based on:
https://github.com/topepo/caret/pull/92
https://github.com/rOpenGov/pxweb/blob/master/.travis.yml
