### PR TITLE
Fixed description based on CRAN review.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: caretEnsemble
 Type: Package
-Title: Framework for combining caret models into ensembles
+Title: Ensembles of Caret Models
 Version: 1.0.0
 Date: 2014-12-18
 Authors@R: c(person(c("Zachary", "A."), "Mayer", role = c("aut", "cre"),
@@ -9,14 +9,12 @@ Authors@R: c(person(c("Zachary", "A."), "Mayer", role = c("aut", "cre"),
     email="jknowles@gmail.com"))
 URL: https://github.com/zachmayer/caretEnsemble
 BugReports: https://github.com/zachmayer/caretEnsemble/issues
-Description: This package is built around 3 functions: caretList, caretEnsemble,
-    and caretStack.  caretList is a convenience function for fitting multiple
-    caret::train models to the same dataset.  caretEnsemble will make a linear
-    combination of these models using greedy forward selection, and caretList
-    will make linear or non-linear combinations of these models using a caret
-    model as a meta-model.  Custom caret models are not yet supported.
-    Multi-class classification and combinations mixing classification and
-    regression models in one ensemble are also not yet supported.
+Description: Functions creating ensembles of caret models: caretList,
+    caretEnsemble, and caretStack.  caretList is a convenience function for
+    fitting multiple caret::train models to the same dataset. caretEnsemble will
+    make a linear combination of these models using greedy forward selection,
+    and caretList will make linear or non-linear combinations of these models,
+    using a caret model as a meta-model.
 Depends:
     R (>= 3.1.0),
     caret


### PR DESCRIPTION
Response to the following comments from the CRAN maintainer:
- 'This package' is redundant: what else might it be a description of?
- Describe the package, not what it is not.

Still need to reduce run-time of tests and examples.
