### PR TITLE
Fixing prediction methods to be more standardized

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
 #    caTools,
 #    pbapply,
 #    digest,
+#    grid,
 #    gridExtra,
 before_install:
   - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
@@ -69,7 +70,6 @@ before_install:
   - ./travis-tool.sh r_binary_install glmnet
   - ./travis-tool.sh r_binary_install rpart
   - ./travis-tool.sh r_binary_install kernlab
-  - ./travis-tool.sh r_binary_install grid
   - ./travis-tool.sh r_binary_install lattice
   - ./travis-tool.sh github_package igraph/rigraph
   - ./travis-tool.sh github_package jimhester/covr@4cae287abde5e2cf0c3c73aedeaec4d902dfd3ed

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ before_install:
   - ./travis-tool.sh github_package jimhester/covr@4cae287abde5e2cf0c3c73aedeaec4d902dfd3ed
   - ./travis-tool.sh github_package jimhester/lintr@21607f469c2ce4f999d04a836f9348038a7282e2
   - ./travis-tool.sh github_package hadley/devtools@52bc15bb7eb87105bbf799d7f784054921146c02
-  - ./travis-tool.sh github_package hadley/testthat@c67018fa4970ee3390ea2056efe56726626b07e3'
+  - ./travis-tool.sh github_package hadley/testthat@c67018fa4970ee3390ea2056efe56726626b07e3
 
 install:
   - ./travis-tool.sh install_deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ install:
   - ./travis-tool.sh install_deps
 
 script:
-  - ./travis-tool.sh run_tests
+  - travis_wait ./travis-tool.sh run_tests
 
 after_success:
   - Rscript -e 'library(covr);coveralls()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,93 @@
-# Sample .travis.yml for R projects from https://github.com/craigcitro/r-travis
+# .travis.yml
+#
+# See README.md for instructions, or for more configuration options,
+# see the wiki:
+#   https://github.com/craigcitro/r-travis/wiki
 
 language: c
+sudo: required
 
 env:
-   global:
-     - WARNINGS_ARE_ERRORS=1
-     - R_BUILD_ARGS="--no-manual --no-build-vignettes"
-     - R_CHECK_ARGS="--no-manual --no-build-vignettes --as-cran"
-     - BOOTSTRAP_LATEX=""
-   matrix:
-     - NOT_CRAN="true"
-     - NOT_CRAN="false"
+  global:
+    - WARNINGS_ARE_ERRORS=1
+    - R_CHECK_ARGS="--no-build-vignettes --no-manual --as-cran"
+    - R_BUILD_ARGS="--no-build-vignettes --no-manual"
+    - BOOTSTRAP_LATEX=""
+  matrix:
+    - NOT_CRAN="true"
+    - NOT_CRAN="false"
 
+#Missing deps/suggests:
+#    knitr,
+#    gbm,
+#    caTools,
+#    pbapply,
+#    digest,
+#    gridExtra,
 before_install:
   - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
   - chmod 755 ./travis-tool.sh
+  - sudo mkdir -p /usr/lib/R/library
+  - echo 'R_LIBS=/usr/lib/R/library:/usr/lib/R/site-library/' > ~/.Renviron
+  - sudo chmod 2777 /usr/lib/R/library
   - ./travis-tool.sh bootstrap
-
-install:
-  - ./travis-tool.sh install_deps
+  - ./travis-tool.sh r_binary_install car
+  - ./travis-tool.sh r_binary_install reshape2
+  - ./travis-tool.sh r_binary_install foreach
+  - ./travis-tool.sh r_binary_install plyr
+  - ./travis-tool.sh r_binary_install nlme
+  - ./travis-tool.sh r_binary_install BradleyTerry2
+  - ./travis-tool.sh r_binary_install e1071
+  - ./travis-tool.sh r_binary_install earth
+  - ./travis-tool.sh r_binary_install fastICA
+  - ./travis-tool.sh r_binary_install gam
+  - ./travis-tool.sh r_binary_install ipred
+  - ./travis-tool.sh r_binary_install kernlab
+  - ./travis-tool.sh r_binary_install klaR
+  - ./travis-tool.sh r_binary_install MASS
+  - ./travis-tool.sh r_binary_install ellipse
+  - ./travis-tool.sh r_binary_install mda
+  - ./travis-tool.sh r_binary_install mgcv
+  - ./travis-tool.sh r_binary_install mlbench
+  - ./travis-tool.sh r_binary_install nnet
+  - ./travis-tool.sh r_binary_install party
+  - ./travis-tool.sh r_binary_install pls
+  - ./travis-tool.sh r_binary_install pROC
+  - ./travis-tool.sh r_binary_install proxy
+  - ./travis-tool.sh r_binary_install randomForest
+  - ./travis-tool.sh r_binary_install RANN
+  - ./travis-tool.sh r_binary_install spls
+  - ./travis-tool.sh r_binary_install subselect
+  - ./travis-tool.sh r_binary_install pamr
+  - ./travis-tool.sh r_binary_install superpc
+  - ./travis-tool.sh r_binary_install Cubist
+  - ./travis-tool.sh r_binary_install testthat
+  - ./travis-tool.sh r_binary_install rARPACK
+  - ./travis-tool.sh r_binary_install ggplot2
+  - ./travis-tool.sh r_binary_install reshape2
+  - ./travis-tool.sh r_binary_install data.table
+  - ./travis-tool.sh r_binary_install glmnet
+  - ./travis-tool.sh r_binary_install rpart
+  - ./travis-tool.sh r_binary_install kernlab
+  - ./travis-tool.sh r_binary_install grid
+  - ./travis-tool.sh r_binary_install lattice
   - ./travis-tool.sh github_package igraph/rigraph
   - ./travis-tool.sh github_package jimhester/covr@4cae287abde5e2cf0c3c73aedeaec4d902dfd3ed
   - ./travis-tool.sh github_package jimhester/lintr@21607f469c2ce4f999d04a836f9348038a7282e2
   - ./travis-tool.sh github_package hadley/devtools@52bc15bb7eb87105bbf799d7f784054921146c02
-  - ./travis-tool.sh github_package hadley/testthat@c67018fa4970ee3390ea2056efe56726626b07e3
+  - ./travis-tool.sh github_package hadley/testthat@c67018fa4970ee3390ea2056efe56726626b07e3'
 
-script: ./travis-tool.sh run_tests
+install:
+  - ./travis-tool.sh install_deps
 
-on_failure:
-  - ./travis-tool.sh dump_logs
+script:
+  - ./travis-tool.sh run_tests
 
 after_success:
   - Rscript -e 'library(covr);coveralls()'
+
+after_failure:
+  - ./travis-tool.sh dump_logs
 
 notifications:
   email:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,2 +1,15 @@
-#caretEnsemble 1.0 - First CRAN release
+#NEWS 
+
+## caretEnsemble 1.0.5
+
+- Change output for predict functions to better align with other predict methods 
+in R (predict.caretEnsemble and predict.caretStack)
+- Update documentation for predict methods to better explain the model disagreement 
+calculation
+- Speed and memory improvements by switching to data.table for some internals
+- Modified the formula for a weighted standard deviation in the model disagreement 
+calculation
+
+## caretEnsemble 1.0 - First CRAN release
+
 * caretEnsemble is a new package for making ensembles of [caret](http://cran.r-project.org/web/packages/caret/index.html) models.

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -8,4 +8,4 @@ assign(".datatable.aware", TRUE)
 
 utils::globalVariables(
   c(".fitted", ".resid", "method", "id", "yhat",
-    "ymax", "yavg", "ymin", "metric", "metricSD"))
+    "ymax", "yavg", "ymin", "metric", "metricSD", "n"))

--- a/R/caretEnsemble.R
+++ b/R/caretEnsemble.R
@@ -106,7 +106,7 @@ caretEnsemble <- function(all.models, optFUN=NULL, ...){
 #' turn to make a matrix of predictions, and then multiplies that matrix by the vector of
 #' weights to get a single, combined vector of predictions.
 #' @param object a \code{\link{caretEnsemble}} to make predictions from.
-#' @param keepNA a logical indicating whether predictions should be made for all
+#' @param keepNA deprecated, a logical indicating whether predictions should be made for all
 #' cases where sufficient data exists or only for complete cases across all models. When
 #' TRUE this does not predict for missing values. When FALSE, missing values are overwritten
 #' with predictions where possible.
@@ -138,19 +138,26 @@ caretEnsemble <- function(all.models, optFUN=NULL, ...){
 #' ens <- caretEnsemble(models)
 #' cor(predict(ens, newdata=iris[51:150,1:2]), iris[51:150,3])
 #' }
-predict.caretEnsemble <- function(object, keepNA = TRUE, level = 0.95, se = FALSE,
+predict.caretEnsemble <- function(object, keepNA, level = 0.95, se = FALSE,
                                   return_weights = FALSE, ...){
   stopifnot(is(object$models, "caretList"))
   args <- eval(substitute(alist(...))) # get ellipsis values
   args <- lapply(args, eval, parent.frame()) # convert from symbols to objects
+  if (!missing(keepNA)) {
+    warning("argument keepNA is deprecated; missing data cannot be safely handled.",
+            call. = FALSE)
+    keepNA <- FALSE
+  } else if(missing(keepNA)){
+    keepNA <- FALSE
+  }
   if(exists("newdata", args)){
     # tmp <- args$newdata
     if(anyNA(args$newdata)){
-      stop("Missing data found in newdata. \nCurrently missing data cannot be consistently
-           handled in predict.caretEnsemble. \nPlease omit missing data before using
-           predict.")
+      stop("Missing data found in newdata. \nCurrently missing data cannot be handled
+in predict.caretEnsemble. \nPlease omit missing data before using predict.")
     }
   }
+
 
   # Default se to FALSE
   if(!return_weights %in% c(TRUE, FALSE)){

--- a/R/caretList.R
+++ b/R/caretList.R
@@ -234,12 +234,12 @@ predict.caretList <- function(object, ..., verbose = FALSE){
     type <- x$modelType
     if (type=="Classification"){
       if(x$control$classProbs){
-        predict(x, type="prob", ...)[,2]
+        caret::predict.train(x, type="prob", ...)[,2]
       } else{
-        predict(x, type="raw", ...)
+        caret::predict.train(x, type="raw", ...)
       }
     } else if(type=="Regression"){
-      predict(x, type="raw", ...)
+      caret::predict.train(x, type="raw", ...)
     } else{
       stop(paste("Unknown model type:", type))
     }

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -9,10 +9,10 @@
 #' @param na.rm a logical indicating how to handle missing values, default = FALSE
 wtd.sd <- function (x, w = NULL, na.rm = FALSE) {
   if (na.rm) { w <- w[i <- !is.na(x)]; x <- x[i] }
-    n = length(w)
-    xWbar = weighted.mean(x,w,na.rm=na.rm)
-    wbar = mean(w)
-    out = n/((n-1)*sum(w)^2)*(sum((w*x-wbar*xWbar)^2)-2*xWbar*sum((w-wbar)*(w*x-wbar*xWbar))+xWbar^2*sum((w-wbar)^2))
+    n <- length(w)
+    xWbar <- weighted.mean(x,w,na.rm=na.rm)
+    wbar <- mean(w)
+    out <- n/((n-1)*sum(w)^2)*(sum((w*x-wbar*xWbar)^2)-2*xWbar*sum((w-wbar)*(w*x-wbar*xWbar))+xWbar^2*sum((w-wbar)^2))
     return(out)
 }
 

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -5,30 +5,15 @@
 #' @description Used to weight deviations among ensembled model preditions
 #'
 #' @param x a vector of numerics
-#' @param weights a vector of weights equal to length of x
-#' @param normwt  a logical indicating whether the weights should be normalized to 1
+#' @param w a vector of weights equal to length of x
 #' @param na.rm a logical indicating how to handle missing values, default = FALSE
-wtd.sd <- function (x, weights = NULL, normwt = FALSE, na.rm = FALSE) {
-  if (!length(weights)) {
-    if (na.rm)
-      x <- x[!is.na(x)]
-    return(sd(x))
-  }
-  if(length(weights) != length(x)){
-    warning("length of the weights vector != the length of the x vector,
-            weights are being recycled.")
-  }
-  if (na.rm) {
-    s <- !is.na(x + weights)
-    x <- x[s]
-    weights <- weights[s]
-  }
-  if (normwt){
-    weights <- weights * length(x)/sum(weights)
-  }
-  xbar <- sum(weights * x)/sum(weights)
-  out <- sqrt(sum(weights * ((x - xbar)^2))/(sum(weights)))
-  return(out)
+wtd.sd <- function (x, w = NULL, na.rm = FALSE) {
+  if (na.rm) { w <- w[i <- !is.na(x)]; x <- x[i] }
+    n = length(w)
+    xWbar = weighted.mean(x,w,na.rm=na.rm)
+    wbar = mean(w)
+    out = n/((n-1)*sum(w)^2)*(sum((w*x-wbar*xWbar)^2)-2*xWbar*sum((w-wbar)*(w*x-wbar*xWbar))+xWbar^2*sum((w-wbar)^2))
+    return(out)
 }
 
 #####################################################

--- a/man/predict.caretEnsemble.Rd
+++ b/man/predict.caretEnsemble.Rd
@@ -6,8 +6,8 @@
 turn to make a matrix of predictions, and then multiplies that matrix by the vector of
 weights to get a single, combined vector of predictions.}
 \usage{
-\method{predict}{caretEnsemble}(object, keepNA = TRUE, se = FALSE,
-  return_weights = FALSE, ...)
+\method{predict}{caretEnsemble}(object, keepNA = TRUE, level = 0.95,
+  se = FALSE, return_weights = FALSE, ...)
 }
 \arguments{
 \item{object}{a \code{\link{caretEnsemble}} to make predictions from.}
@@ -17,23 +17,39 @@ cases where sufficient data exists or only for complete cases across all models.
 TRUE this does not predict for missing values. When FALSE, missing values are overwritten
 with predictions where possible.}
 
+\item{level}{tolerance/confidence level}
+
 \item{se}{logical, should prediction errors be produced? Default is false.}
 
 \item{return_weights}{a logical indicating whether prediction weights for each model for
-each observation should be returend}
+each observation should be returned}
 
-\item{...}{arguments (including newdata) to pass to predict.train. These arguments
-must be named}
+\item{...}{additional arguments to pass to predict.train. Pass the \code{newdata}
+argument here, DO NOT PASS the "type" argument.  Classification models will
+return probabilities if possible, and regression models will return "raw".}
 }
 \value{
-If \code{return_weights = TRUE} a list is returned with a data.frame
-slot for predictions and a matrix slot for the model weights. If \code{return_weights = FALSE}
-a data.frame is returned for the predictions.
+If \code{se=TRUE} a data.frame is returned with three columns, fit,
+upr, and lwr which represent the predicted value, and the upper and lower
+confidence intervals, defined by the \code{level} argument. If \code{se=false}
+a numeric vector is returned of the predicted values. If \code{return_weights = TRUE}
+an attribute is attached to the object returned by predict with a matrix of
+the model weights for each observation.
 }
 \description{
 Make predictions from a caretEnsemble. This function passes the data to each function in
 turn to make a matrix of predictions, and then multiplies that matrix by the vector of
 weights to get a single, combined vector of predictions.
+}
+\details{
+The standard error here is not a measure of the uncertainty of the
+predictions within each of the models in the ensemble, but instead a measure
+of disagreement among the models for each observation.
+}
+\note{
+Currently there is no support for NA handling in this function. A future
+update to the \code{caret} package will allow for the proper handling of NA values.
+An error will occur if the user passes newdata that contains missing values.
 }
 \examples{
 \dontrun{

--- a/man/predict.caretEnsemble.Rd
+++ b/man/predict.caretEnsemble.Rd
@@ -6,13 +6,13 @@
 turn to make a matrix of predictions, and then multiplies that matrix by the vector of
 weights to get a single, combined vector of predictions.}
 \usage{
-\method{predict}{caretEnsemble}(object, keepNA = TRUE, level = 0.95,
-  se = FALSE, return_weights = FALSE, ...)
+\method{predict}{caretEnsemble}(object, keepNA, level = 0.95, se = FALSE,
+  return_weights = FALSE, ...)
 }
 \arguments{
 \item{object}{a \code{\link{caretEnsemble}} to make predictions from.}
 
-\item{keepNA}{a logical indicating whether predictions should be made for all
+\item{keepNA}{deprecated, a logical indicating whether predictions should be made for all
 cases where sufficient data exists or only for complete cases across all models. When
 TRUE this does not predict for missing values. When FALSE, missing values are overwritten
 with predictions where possible.}

--- a/man/predict.caretStack.Rd
+++ b/man/predict.caretStack.Rd
@@ -4,12 +4,20 @@
 \alias{predict.caretStack}
 \title{Make predictions from a caretStack}
 \usage{
-\method{predict}{caretStack}(object, newdata = NULL, ...)
+\method{predict}{caretStack}(object, newdata = NULL, se = FALSE,
+  level = NULL, return_weights = FALSE, ...)
 }
 \arguments{
 \item{object}{a  \code{\link{caretStack}} to make predictions from.}
 
 \item{newdata}{a new dataframe to make predictions on}
+
+\item{se}{logical, should prediction errors be produced? Default is false.}
+
+\item{level}{tolerance/confidence level}
+
+\item{return_weights}{a logical indicating whether prediction weights for each model
+should be returned}
 
 \item{...}{arguments to pass to \code{\link{predict.train}}.}
 }
@@ -17,6 +25,11 @@
 Make predictions from a caretStack. This function passes the data to each function in
 turn to make a matrix of predictions, and then multiplies that matrix by the vector of
 weights to get a single, combined vector of predictions.
+}
+\details{
+Prediction weights are defined as variable importance in the stacked
+caret model. This is not available for all cases such as where the library
+model predictions are transformed before being passed to the stacking model.
 }
 \examples{
 \dontrun{

--- a/man/wtd.sd.Rd
+++ b/man/wtd.sd.Rd
@@ -4,14 +4,12 @@
 \alias{wtd.sd}
 \title{Calculate a weighted standard deviation}
 \usage{
-wtd.sd(x, weights = NULL, normwt = FALSE, na.rm = FALSE)
+wtd.sd(x, w = NULL, na.rm = FALSE)
 }
 \arguments{
 \item{x}{a vector of numerics}
 
-\item{weights}{a vector of weights equal to length of x}
-
-\item{normwt}{a logical indicating whether the weights should be normalized to 1}
+\item{w}{a vector of weights equal to length of x}
 
 \item{na.rm}{a logical indicating how to handle missing values, default = FALSE}
 }

--- a/tests/testthat/test-caretStack.R
+++ b/tests/testthat/test-caretStack.R
@@ -23,7 +23,7 @@ test_that("We can stack regression models", {
   expect_that(ens.reg, is_a("caretStack"))
   expect_is(summary(ens.reg), "summary.lm")
   sink <- capture.output(print(ens.reg))
-  pred.reg <- predict(ens.reg, X.reg)
+  pred.reg <- predict(ens.reg, newdata = X.reg)
   expect_true(is.numeric(pred.reg))
   expect_true(length(pred.reg)==150)
 })
@@ -35,7 +35,7 @@ test_that("We can stack classification models", {
   expect_that(ens.class, is_a("caretStack"))
   expect_is(summary(ens.class), "summary.glm")
   sink <- capture.output(print(ens.class))
-  pred.class <- predict(ens.class, X.class, type="prob")[,2]
+  pred.class <- predict(ens.class, X.class, type="prob")
   expect_true(is.numeric(pred.class))
   expect_true(length(pred.class)==150)
   raw.class <- predict(ens.class, X.class, type="raw")
@@ -54,4 +54,33 @@ test_that("caretStack plots", {
   dotplot(ens.reg, metric="RMSE")
   dev.off()
   unlink(test_plot_file)
+})
+
+context("Prediction errors for caretStack work as expected")
+
+test_that("Failure to calculate se occurs gracefully", {
+  ens.class <- caretStack(models.class, method="glm",
+                          trControl=trainControl(number=2, allowParallel=FALSE))
+  expect_message(predict(ens.class, X.class, type="raw", se = TRUE))
+  expect_is(predict(ens.class, X.class, type="raw"), "factor")
+  expect_is(predict(ens.class, X.class, type="raw", se=TRUE), "factor")
+  expect_identical(predict(ens.class, X.class, type="raw", se=TRUE),
+                   predict(ens.class, X.class, type="raw"))
+  ens.reg <- caretStack(models.reg, method="lm", preProcess="pca",
+                        trControl=trainControl(number=2, allowParallel=FALSE))
+  expect_message(predict(ens.reg, X.reg, se=TRUE))
+  expect_is(predict(ens.reg, X.reg, se=TRUE), "numeric")
+  expect_identical(predict(ens.reg, X.reg, se=TRUE), predict(ens.reg, X.reg))
+  #
+  expect_is(predict(ens.class, X.class, type="prob", se=TRUE), "data.frame")
+  expect_is(predict(ens.class, X.class, type="prob", se=TRUE, return_weights=TRUE),
+            "data.frame")
+  expect_identical(colnames(predict(ens.class, X.class, type="prob", se=TRUE)),
+                   c("fit", "lwr", "upr"))
+  expect_false(identical(predict(ens.class, X.class, type="raw", return_weights=TRUE),
+                         predict(ens.class, X.class, type="raw", return_weights=FALSE)))
+  expect_false(identical(predict(ens.class, X.class, type="prob", se = TRUE, level=0.8),
+                         predict(ens.class, X.class, type="prob", se=TRUE, return_weights=FALSE)))
+  expect_true(identical(predict(ens.class, X.class, type="prob", level=0.8),
+                        predict(ens.class, X.class, type="prob", return_weights=FALSE)))
 })

--- a/tests/testthat/test-ensemble.R
+++ b/tests/testthat/test-ensemble.R
@@ -107,6 +107,8 @@ test_that("We can ensemble regression models", {
   p7 <- predict(ens.reg, return_weights=FALSE, se=FALSE, keepNA=TRUE)
   p8 <- predict(ens.reg, return_weights=FALSE, se=TRUE, keepNA=TRUE)
 
+
+
   #Check preds
   #I don't like how much the output data structure varies, depending on the input
   #I feel like it maybe should be a single lists, with none of this

--- a/tests/testthat/test-ensemble.R
+++ b/tests/testthat/test-ensemble.R
@@ -153,6 +153,9 @@ test_that("We can ensemble models of different predictors", {
   pred.nest <- predict(ensNest, newdata = X.reg)
   expect_true(is.numeric(pred.nest))
   expect_true(length(pred.nest)==150)
+  X.reg[2, 3] <- NA
+  X.reg[25, 3] <- NA
+  expect_error(predict(ensNest, newdata = X.reg))
 })
 
 # context("Does ensembling work with missingness")

--- a/tests/testthat/test-ensembleMethods.R
+++ b/tests/testthat/test-ensembleMethods.R
@@ -445,6 +445,14 @@ test_that("Prediction options are respected in regression and classification", {
       expect_is(p, "numeric")
       preds <- p
     }
+    if(tests[i, "keepNA"]){
+      expect_warning(predict(
+        ens.class,
+        keepNA=tests[i,"keepNA"],
+        se=tests[i,"se"],
+        return_weights=tests[i,"return_weights"]
+      ), "argument keepNA is deprecated; missing data cannot be safely handled.")
+    }
 
     if(tests[i,"return_weights"]){
       expect_is(attr(preds, which = "weights"), "matrix")

--- a/tests/testthat/test-helper_functions.R
+++ b/tests/testthat/test-helper_functions.R
@@ -20,7 +20,7 @@ load(system.file("testdata/Y.class.rda",
                  package="caretEnsemble", mustWork=TRUE))
 
 test_that("Recycling generates a warning", {
-  expect_warning(wtd.sd(matrix(1:10, ncol=2),weights=1))
+  expect_error(caretEnsemble:::wtd.sd(matrix(1:10, ncol=2), w=1))
 })
 
 test_that("No predictions generates an error", {
@@ -113,34 +113,30 @@ test_that("predict results same regardless of verbose option", {
 context("Test weighted standard deviations")
 
 x <- rnorm(1000)
-y <- runif(1000)
 x1 <- c(3, 5, 9, 3, 4, 6, 4)
 x2 <- c(10, 10, 20, 14, 2, 2, 40)
 y <- c(10, 10, 10, 20)
 w1 <- c(0.1, 0.1, 0.1, 0.7)
 
 test_that("wtd.sd applies weights correctly", {
-  expect_equal(sd(x), wtd.sd(x))
-  expect_false(sd(x1) == wtd.sd(x1, weights = x2))
-  expect_false(sd(x1) == wtd.sd(x1, weights = x2, normwt=TRUE))
-  expect_true(sd(x1) == wtd.sd(x1))
-  expect_equal(sd(y), 5)
-  expect_equal(wtd.sd(y, weights = w1), 4.582576, tolerance = .001)
-  expect_equal(wtd.sd(y, weights = w1), wtd.sd(y, weights = w1, normwt=TRUE))
-  expect_equal(wtd.sd(y, weights = w1*100), wtd.sd(y, weights = w1*100, normwt=TRUE))
+  expect_error(caretEnsemble:::wtd.sd(x))
+  expect_false(sd(x1) == wtd.sd(x1, w = x2))
+  expect_false(sd(x1) == wtd.sd(x1, w = x2))
+  expect_equal(caretEnsemble:::wtd.sd(y, w = w1), 7.84, tolerance = .001)
+  expect_equal(caretEnsemble:::wtd.sd(y, w = w1*100), caretEnsemble:::wtd.sd(y, w = w1))
 })
 
 test_that("wtd.sd handles NA values correctly", {
   y <- c(10, 10, 10, 20, NA, NA)
   w1 <- c(0.1, 0.1, 0.1, 0.7, NA, NA)
-  expect_true(is.na(wtd.sd(y)))
+  expect_true(is.na(caretEnsemble:::wtd.sd(y, w = w1)))
   expect_true(is.na(sd(y)))
-  expect_true(!is.na(wtd.sd(y, na.rm=TRUE)))
+  expect_true(!is.na(caretEnsemble:::wtd.sd(y, w = w1, na.rm=TRUE)))
   expect_true(!is.na(sd(y, na.rm=TRUE)))
-  expect_true(is.na(wtd.sd(y, weights = w1)))
-  expect_true(!is.na(wtd.sd(y, weights = w1, na.rm=TRUE)))
+  expect_true(is.na(caretEnsemble:::wtd.sd(y, w = w1)))
+  expect_true(!is.na(caretEnsemble:::wtd.sd(y, w = w1, na.rm=TRUE)))
   w2 <- c(0.1, 0.1, NA, 0.7, NA, NA)
-  expect_false(wtd.sd(y, weights = w1, na.rm=TRUE, normwt = TRUE) == wtd.sd(y, weights = w2, na.rm=TRUE, normwt = TRUE))
+  expect_true(is.na(caretEnsemble:::wtd.sd(y, w = w1, na.rm=TRUE) == caretEnsemble:::wtd.sd(y, w = w2, na.rm=TRUE)))
 })
 
 test_that("Checks generate errors", {

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -1,43 +1,43 @@
 context("Parallelization works")
 test_that("predict.caretEnsemble works in parallel", {
   skip_on_cran()
-  X.reg <- model.matrix(~ ., iris[, -1])
-  X.reg.big <- do.call(rbind, lapply(1:100, function(x) X.reg))
-  Y.reg <- iris[, 1]
-  ens.reg <- caretEnsemble(caretList(X.reg, Y.reg, methodList=c("lm", "glm")))
+  X_reg <- model.matrix(~ ., iris[, -1])
+  X_reg_big <- do.call(rbind, lapply(1:100, function(x) X_reg))
+  Y_reg <- iris[, 1]
+  ens_reg <- caretEnsemble(caretList(X_reg, Y_reg, methodList=c("lm", "glm")))
 
   #Basic
-  pred.reg <- predict(ens.reg, newdata = X.reg)
-  pred.reg2 <- predict(ens.reg, newdata = X.reg.big)
-  expect_equal(pred.reg, pred.reg2[1:length(pred.reg)])
+  pred_reg <- predict(ens_reg, newdata = X_reg)
+  pred_reg2 <- predict(ens_reg, newdata = X_reg_big)
+  expect_equal(pred_reg, pred_reg2[1:length(pred_reg)])
 
   #Don't keep NAs
-  pred.reg <- predict(ens.reg, newdata = X.reg, keepNA = FALSE)
-  pred.reg2 <- predict(ens.reg, newdata = X.reg.big, keepNA = FALSE)
-  expect_equal(pred.reg, pred.reg2[1:length(pred.reg)])
+  pred_reg <- predict(ens_reg, newdata = X_reg, keepNA = FALSE)
+  pred_reg2 <- predict(ens_reg, newdata = X_reg_big, keepNA = FALSE)
+  expect_equal(pred_reg, pred_reg2[1:length(pred_reg)])
 
   #Return se
-  pred.reg <- predict(ens.reg, newdata = X.reg, se = TRUE)
-  pred.reg2 <- predict(ens.reg, newdata = X.reg.big, se = TRUE)
-  expect_equal(pred.reg, pred.reg2[1:nrow(pred.reg), ])
+  pred_reg <- predict(ens_reg, newdata = X_reg, se = TRUE)
+  pred_reg2 <- predict(ens_reg, newdata = X_reg_big, se = TRUE)
+  expect_equal(pred_reg, pred_reg2[1:nrow(pred_reg), ])
 
   #Return weights
-  pred.reg <- predict(ens.reg, newdata = X.reg, se = TRUE, return_weights = TRUE)
-  pred.reg2 <- predict(
-    ens.reg, newdata = X.reg.big, se = TRUE, return_weights = TRUE
+  pred_reg <- predict(ens_reg, newdata = X_reg, se = TRUE, return_weights = TRUE)
+  pred_reg2 <- predict(
+    ens_reg, newdata = X_reg_big, se = TRUE, return_weights = TRUE
     )
-  expect_equal(pred.reg$preds, pred.reg2$preds[1:nrow(pred.reg$preds),])
+  expect_equal(pred_reg$preds, pred_reg2$preds[1:nrow(pred_reg$preds),])
 
   #Don't keep NAs, return se
-  pred.reg <- predict(ens.reg, newdata = X.reg, keepNA = FALSE, se = TRUE)
-  pred.reg2 <- predict(ens.reg, newdata = X.reg.big, keepNA = FALSE, se = TRUE)
-  expect_equal(pred.reg, pred.reg2[1:nrow(pred.reg), ])
+  pred_reg <- predict(ens_reg, newdata = X_reg, keepNA = FALSE, se = TRUE)
+  pred_reg2 <- predict(ens_reg, newdata = X_reg_big, keepNA = FALSE, se = TRUE)
+  expect_equal(pred_reg, pred_reg2[1:nrow(pred_reg), ])
 
   #Don't keep NAs, return se, return weights
-  pred.reg <- predict(
-    ens.reg, newdata = X.reg, keepNA = FALSE, se = TRUE, return_weights = TRUE)
-  pred.reg2 <- predict(
-    ens.reg, newdata = X.reg.big, keepNA = FALSE, se = TRUE,
+  pred_reg <- predict(
+    ens_reg, newdata = X_reg, keepNA = FALSE, se = TRUE, return_weights = TRUE)
+  pred_reg2 <- predict(
+    ens_reg, newdata = X_reg_big, keepNA = FALSE, se = TRUE,
     return_weights = TRUE)
-  expect_equal(pred.reg$preds, pred.reg2$preds[1:nrow(pred.reg$preds),])
+  expect_equal(pred_reg$preds, pred_reg2$preds[1:nrow(pred_reg$preds),])
 })

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -1,0 +1,43 @@
+context("Parallelization works")
+test_that("predict.caretEnsemble works in parallel", {
+  skip_on_cran()
+  X.reg <- model.matrix(~ ., iris[, -1])
+  X.reg.big <- do.call(rbind, lapply(1:100, function(x) X.reg))
+  Y.reg <- iris[, 1]
+  ens.reg <- caretEnsemble(caretList(X.reg, Y.reg, methodList=c("lm", "glm")))
+
+  #Basic
+  pred.reg <- predict(ens.reg, newdata = X.reg)
+  pred.reg2 <- predict(ens.reg, newdata = X.reg.big)
+  expect_equal(pred.reg, pred.reg2[1:length(pred.reg)])
+
+  #Don't keep NAs
+  pred.reg <- predict(ens.reg, newdata = X.reg, keepNA = FALSE)
+  pred.reg2 <- predict(ens.reg, newdata = X.reg.big, keepNA = FALSE)
+  expect_equal(pred.reg, pred.reg2[1:length(pred.reg)])
+
+  #Return se
+  pred.reg <- predict(ens.reg, newdata = X.reg, se = TRUE)
+  pred.reg2 <- predict(ens.reg, newdata = X.reg.big, se = TRUE)
+  expect_equal(pred.reg, pred.reg2[1:nrow(pred.reg), ])
+
+  #Return weights
+  pred.reg <- predict(ens.reg, newdata = X.reg, se = TRUE, return_weights = TRUE)
+  pred.reg2 <- predict(
+    ens.reg, newdata = X.reg.big, se = TRUE, return_weights = TRUE
+    )
+  expect_equal(pred.reg$preds, pred.reg2$preds[1:nrow(pred.reg$preds),])
+
+  #Don't keep NAs, return se
+  pred.reg <- predict(ens.reg, newdata = X.reg, keepNA = FALSE, se = TRUE)
+  pred.reg2 <- predict(ens.reg, newdata = X.reg.big, keepNA = FALSE, se = TRUE)
+  expect_equal(pred.reg, pred.reg2[1:nrow(pred.reg), ])
+
+  #Don't keep NAs, return se, return weights
+  pred.reg <- predict(
+    ens.reg, newdata = X.reg, keepNA = FALSE, se = TRUE, return_weights = TRUE)
+  pred.reg2 <- predict(
+    ens.reg, newdata = X.reg.big, keepNA = FALSE, se = TRUE,
+    return_weights = TRUE)
+  expect_equal(pred.reg$preds, pred.reg2$preds[1:nrow(pred.reg$preds),])
+})

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -26,7 +26,7 @@ test_that("predict.caretEnsemble works in parallel", {
   pred_reg2 <- predict(
     ens_reg, newdata = X_reg_big, se = TRUE, return_weights = TRUE
     )
-  expect_equal(pred_reg$preds, pred_reg2$preds[1:nrow(pred_reg$preds),])
+  expect_equal(pred_reg$fit, pred_reg2$fit[1:length(pred_reg$fit)])
 
   #Don't keep NAs, return se
   pred_reg <- predict(ens_reg, newdata = X_reg, keepNA = FALSE, se = TRUE)
@@ -39,5 +39,5 @@ test_that("predict.caretEnsemble works in parallel", {
   pred_reg2 <- predict(
     ens_reg, newdata = X_reg_big, keepNA = FALSE, se = TRUE,
     return_weights = TRUE)
-  expect_equal(pred_reg$preds, pred_reg2$preds[1:nrow(pred_reg$preds),])
+  expect_equal(pred_reg$fit, pred_reg2$fit[1:nrow(pred_reg)])
 })


### PR DESCRIPTION
This PR addresses #165 and #158 by making sure that `predict.caretEnsemble` and `predict.caretStack` provide similar output and have similar inputs. There are also large changes to the unit tests to make sure that the tests now test the correct structure for the output from these two functions. 

`predict.caretStack` is particularly heavily modified here -- it now can produce prediction errors based on the model disagreement about each observation, mimicking the behavior of `predict.caretEnsemble`. It uses the variable importance of each models' predictions in the stacked model to define the weights. When these predictions are transformed before ensembling, no standard error is returned or calculated, but the variable importance can still be returned as a `weights` attribute to the outputted vector. 