### PR TITLE
Predict bug fix

### DIFF
--- a/R/caretList.R
+++ b/R/caretList.R
@@ -244,7 +244,12 @@ predict.caretList <- function(object, ..., verbose = FALSE){
       stop(paste("Unknown model type:", type))
     }
   })
+  if(class(preds) != "matrix" & class(preds) != "data.frame"){
+    if(class(preds) == "character" | class(preds) == "factor"){
+      preds <- as.character(preds) # drop factorization
+    }
+    preds <- as.matrix(t(preds))
+  }
   colnames(preds) <- make.names(sapply(object, function(x) x$method), unique=TRUE)
-
   return(preds)
 }

--- a/tests/testthat/test-caretList.R
+++ b/tests/testthat/test-caretList.R
@@ -97,6 +97,7 @@ test_that("caretList predictions", {
   p1 <- predict(models)
   p2 <- predict(models, newdata = iris[100, c(1:2)])
   p3 <- predict(models, newdata = iris[110, c(1:2)])
+  expect_error(predict(models, newdata = iris[110, ]))
   expect_is(p1, "matrix")
   expect_is(p1[,1], "character")
   expect_is(p1[,2], "character")
@@ -113,13 +114,17 @@ test_that("caretList predictions", {
   models <- caretList(
     iris[,1:2], iris[,5],
     tuneLength=1, verbose=FALSE,
-    methodList=c("rf", "gbm"),
+    methodList=c("rf", "nnet"),
     trControl=trainControl(method="cv", number=2, savePredictions=TRUE, classProbs=TRUE))
   p2 <- predict(models)
-  # p3 <- predict(models, newdata = iris[100, c(1:2)])
+  p3 <- predict(models, newdata = iris[100, c(1:2)])
   expect_is(p2, "matrix")
   expect_is(p2[,1], "numeric")
   expect_is(p2[,2], "numeric")
+  expect_is(p3, "matrix")
+  expect_is(p3[,1], "numeric")
+  expect_is(p3[,2], "numeric")
+  expect_equal(names(models), colnames(p3))
 
   models[[1]]$modelType <- "Bogus"
   expect_error(predict(models))

--- a/tests/testthat/test-caretList.R
+++ b/tests/testthat/test-caretList.R
@@ -95,9 +95,20 @@ test_that("caretList predictions", {
     methodList=c("rf", "gbm"),
     trControl=trainControl(method="cv", number=2, savePredictions=TRUE, classProbs=FALSE))
   p1 <- predict(models)
+  p2 <- predict(models, newdata = iris[100, c(1:2)])
+  p3 <- predict(models, newdata = iris[110, c(1:2)])
   expect_is(p1, "matrix")
   expect_is(p1[,1], "character")
   expect_is(p1[,2], "character")
+  expect_equal(names(models), colnames(p1))
+  expect_is(p2, "matrix")
+  expect_is(p2[,1], "character")
+  expect_is(p2[,2], "character")
+  expect_equal(names(models), colnames(p2))
+  expect_is(p3, "matrix")
+  expect_is(p3[,1], "character")
+  expect_is(p3[,2], "character")
+  expect_equal(names(models), colnames(p3))
 
   models <- caretList(
     iris[,1:2], iris[,5],
@@ -105,6 +116,7 @@ test_that("caretList predictions", {
     methodList=c("rf", "gbm"),
     trControl=trainControl(method="cv", number=2, savePredictions=TRUE, classProbs=TRUE))
   p2 <- predict(models)
+  # p3 <- predict(models, newdata = iris[100, c(1:2)])
   expect_is(p2, "matrix")
   expect_is(p2[,1], "numeric")
   expect_is(p2[,2], "numeric")

--- a/tests/testthat/test-ensemble.R
+++ b/tests/testthat/test-ensemble.R
@@ -158,4 +158,49 @@ test_that("We can ensemble models of different predictors", {
   expect_error(predict(ensNest, newdata = X.reg))
 })
 
-# context("Does ensembling work with missingness")
+context("Does ensemble prediction work with new data")
+
+test_that("It works for regression models", {
+  load(system.file("testdata/models.reg.rda",
+                   package="caretEnsemble", mustWork=TRUE))
+  load(system.file("testdata/X.reg.rda",
+                   package="caretEnsemble", mustWork=TRUE))
+  load(system.file("testdata/Y.reg.rda",
+                   package="caretEnsemble", mustWork=TRUE))
+  ens.reg <- caretEnsemble(models.reg, iter=1000)
+  expect_that(ens.reg, is_a("caretEnsemble"))
+  pred.reg <- predict(ens.reg)
+  newPreds1 <- as.data.frame(X.reg)
+  pred.regb <- predict(ens.reg, newdata = newPreds1)
+  pred.regc <- predict(ens.reg, newdata = newPreds1[2, ])
+  expect_identical(pred.reg, pred.regb)
+  expect_equal(pred.regc, 4.724, tol = .001)
+  expect_is(pred.reg, "numeric")
+  expect_is(pred.regb, "numeric")
+  expect_is(pred.regc, "numeric")
+  expect_equal(length(pred.regc), 1)
+})
+
+
+test_that("It works for classification models", {
+  load(system.file("testdata/models.class.rda",
+                   package="caretEnsemble", mustWork=TRUE))
+  load(system.file("testdata/X.class.rda",
+                   package="caretEnsemble", mustWork=TRUE))
+  load(system.file("testdata/Y.class.rda",
+                   package="caretEnsemble", mustWork=TRUE))
+  ens.class <- caretEnsemble(models.class, iter=1000)
+  expect_that(ens.class, is_a("caretEnsemble"))
+  pred.class <- predict(ens.class)
+  newPreds1 <- as.data.frame(X.class)
+  pred.classb <- predict(ens.class, newdata = newPreds1)
+  pred.classc <- predict(ens.class, newdata = newPreds1[2, ])
+  expect_true(is.numeric(pred.class))
+  expect_true(length(pred.class)==150)
+  expect_identical(pred.class, pred.classb)
+  expect_equal(pred.classc, .004834, tol = .001)
+  expect_is(pred.class, "numeric")
+  expect_is(pred.classb, "numeric")
+  expect_is(pred.classc, "numeric")
+  expect_equal(length(pred.classc), 1)
+})

--- a/tests/testthat/test-ensembleMethods.R
+++ b/tests/testthat/test-ensembleMethods.R
@@ -316,9 +316,9 @@ test_that("Residuals provided by residuals are proper for ensemble objects", {
   expect_equal(residuals(ens.reg2), residuals(ens.reg))
 })
 
-context("Does prediction method work for classification")
+context("Are ensembles construct accurately")
 
-test_that("We can ensemble models and handle missingness across predictors", {
+test_that("Do model results in caretEnsemble match component models - classification", {
   skip_on_cran()
   load(system.file("testdata/models.reg.rda",
                    package="caretEnsemble", mustWork=TRUE))
@@ -364,9 +364,7 @@ test_that("We can ensemble models and handle missingness across predictors", {
   expect_true(nrow(modF2) == nrow(ens.reg$models[[1]]$trainingData))
 })
 
-context("Does prediction method work for regression")
-
-test_that("We can ensemble models and handle missingness across predictors", {
+test_that("Do model results in caretEnsemble match component models - regression", {
   skip_on_cran()
   load(system.file("testdata/models.reg.rda",
                    package="caretEnsemble", mustWork=TRUE))

--- a/tests/testthat/test-helper_functions.R
+++ b/tests/testthat/test-helper_functions.R
@@ -146,7 +146,7 @@ test_that("Checks generate errors", {
   myControl <- trainControl(method="cv", number=5, savePredictions=TRUE)
   x <- caretList(
     Sepal.Length ~ Sepal.Width,
-    head(iris, 100),
+    iris,
     methodList=c("glm", "lm"),
     trControl=myControl
   )
@@ -157,14 +157,18 @@ test_that("Checks generate errors", {
   expect_error(check_bestpreds_indexes(modelLibrary))
   expect_error(check_bestpreds_obs(modelLibrary))
 
-  x$rpart <- train(Sepal.Length ~ Sepal.Width, head(iris, 100), method="rpart")
+  x$rpart <- train(Sepal.Length ~ Sepal.Width, iris, method="rpart")
   expect_error(check_bestpreds_resamples(modelLibrary))
   expect_error(check_bestpreds_indexes(modelLibrary))
   expect_error(check_bestpreds_obs(modelLibrary))
 
   expect_error(check_caretList_classes(x$glm$finalModel))
 
-  x$rpart <- train(Species ~ Sepal.Width, head(iris, 100), method="rpart", trControl=myControl)
+  x$rpart <- train(Species ~ Sepal.Width, iris, method="rpart", trControl=myControl)
+  # This has to be changed because train gives this error if dataset is truncated in
+  # newest version of caret:
+  # Error in train.default(x, y, weights = w, ...) :
+  #    One or more factor levels in the outcome has no data: 'virginica'
   check_caretList_classes(x)
   expect_error(check_caretList_model_types(x))
 
@@ -185,6 +189,6 @@ test_that("Checks generate errors", {
     methodList=c("lda", "rf"),
     trControl=myControl2
   )
-  x$rpart <- train(Species ~ Sepal.Width + Sepal.Length, head(iris, 100), method="rpart")
+  x$rpart <- train(Species ~ Sepal.Width + Sepal.Length, iris, method="rpart")
   expect_error(check_caretList_model_types(x))
 })

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -1,0 +1,23 @@
+# library(caretEnsemble)
+# library('mlbench')
+# data(Sonar)
+#
+# my_control <- trainControl(
+#   method='boot',
+#   number=25,
+#   savePredictions=TRUE,
+#   classProbs=TRUE,
+#   index=createResample(Sonar$Class, 25)
+# )
+#
+# model_list <- caretList(
+#   Class~., data=Sonar,
+#   trControl=my_control,
+#   methodList=c('glm', 'rpart')
+# )
+#
+# greedy_ensemble <- caretEnsemble(model_list)
+#
+# list_preds <- predict(model_list, newdata = Sonar[1, ])
+# ens_preds <- predict(greedy_ensemble, newdata=Sonar[1,])
+# ens_preds <- predict(greedy_ensemble, newdata=rbind(Sonar[1,],Sonar[1,]))[1]

--- a/vignettes/caretEnsemble-intro.Rmd
+++ b/vignettes/caretEnsemble-intro.Rmd
@@ -178,7 +178,7 @@ gbm_ensemble <- caretStack(
   )
 )
 model_preds3 <- model_preds
-model_preds3$ensemble <- predict(gbm_ensemble, newdata=testing, type="prob")$M
+model_preds3$ensemble <- predict(gbm_ensemble, newdata=testing, type="prob") #$M
 colAUC(model_preds3, testing$Class)
 ```
 


### PR DESCRIPTION
This should solve #172 and I added a bunch of unit tests. 

I also noticed that the fix for #167 seems to have caused an error with building the vignette, so I made a change to that, though I'm not sure it's correct. 

While I was testing this I noticed some new errors introduced if using the latest, development version, of `caret` introduced some errors around the unit tests for `test-helperfunctions` -- namely about using only the first 100 observations of `iris` instead of the whole dataset. This is because `train` now throws an error if there are three factor levels, but one of them is unobserved in the data. An alternative fix to how I have chosen to fix this is to refactor the outcome column of `iris` to be a two-level factor and then run the tests through with 100 observations. I wasn't sure the rationale for using only 100 observations, but figured if it is just speed, the extra 50 observations wouldn't make much difference. 