### PR TITLE
Fix ordering by y(obs) issue

### DIFF
--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -329,11 +329,11 @@ makePredObsMatrix <- function(list_of_models){
     set(modelLibrary, j="pred", value=as.numeric(modelLibrary[["pred"]]))
     set(modelLibrary, i=good_pos_values, j="pred", value=modelLibrary[good_pos_values, positive, with=FALSE])
   }
-
+  
   #Reshape wide for meta-modeling
   modelLibrary <- data.table::dcast.data.table(
     modelLibrary,
-    obs + rowIndex + Resample ~ modelname,
+    rowIndex + obs + Resample ~ modelname,
     value.var = "pred"
   )
 

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -329,7 +329,7 @@ makePredObsMatrix <- function(list_of_models){
     set(modelLibrary, j="pred", value=as.numeric(modelLibrary[["pred"]]))
     set(modelLibrary, i=good_pos_values, j="pred", value=modelLibrary[good_pos_values, positive, with=FALSE])
   }
-  
+
   #Reshape wide for meta-modeling
   modelLibrary <- data.table::dcast.data.table(
     modelLibrary,


### PR DESCRIPTION
Instead of keeping the original ordering caretEnsemble has been ordering the
x and y by the value of y (the obs).  Fixed to order by rowIndex
instead.