### PR TITLE
Makes all CaretList's regression predictions be numeric

### DIFF
--- a/R/caretList.R
+++ b/R/caretList.R
@@ -233,7 +233,15 @@ caretList <- function(
     } else{
       model <- do.call(train, model_args)
     }
-    if(!is.null(model)) model$pred$pred <- as.numeric(model$pred$pred)               
+
+    if(!is.null(model)){
+      if(model$modelType != "Regression"){
+        model$pred$pred <- as.factor(model$pred$pred)
+      } else{
+        model$pred$pred <- as.numeric(model$pred$pred)
+      }
+    }
+
     return(model)
   })
   names(modelList) <- names(tuneList)
@@ -243,8 +251,7 @@ caretList <- function(
   if(length(modelList)==0){
     stop("caret:train failed for all models.  Please inspect your data.")
   }
-      
-      
+
   class(modelList) <- c("caretList")
 
   return(modelList)

--- a/R/caretList.R
+++ b/R/caretList.R
@@ -233,6 +233,7 @@ caretList <- function(
     } else{
       model <- do.call(train, model_args)
     }
+    if(!is.null(model)) model$pred$pred <- as.numeric(model$pred$pred)               
     return(model)
   })
   names(modelList) <- names(tuneList)
@@ -242,6 +243,8 @@ caretList <- function(
   if(length(modelList)==0){
     stop("caret:train failed for all models.  Please inspect your data.")
   }
+      
+      
   class(modelList) <- c("caretList")
 
   return(modelList)

--- a/R/caretList.R
+++ b/R/caretList.R
@@ -235,9 +235,7 @@ caretList <- function(
     }
 
     if(!is.null(model)){
-      if(model$modelType != "Regression"){
-        model$pred$pred <- as.factor(model$pred$pred)
-      } else{
+      if(model$modelType == "Regression"){
         model$pred$pred <- as.numeric(model$pred$pred)
       }
     }


### PR DESCRIPTION
Caret not always returns numeric or factor predictions, instead sometimes it returns them as character wich results in errors in the caretEnsemble and caretStack functions. The underlying packages that implement the models themselves are in constant change and cannot be 100% trusted to always give the numeric values caretEnsemble and caretStack expect. In order to solve this issue, the line  if(!is.null(model)) model$pred$pred <- as.numeric(model$pred$pred) can be added on the caretList function.