### PR TITLE
initial multiclass support - take 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: all install document update-test-fixtures test coverage-test check-cran fix-style lint clean
 
 # Default target
-all: fix-style install document test check-cran coverage-test
+all: clean fix-style install document test check-cran coverage-test
 
 # Install dependencies
 install:

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -97,17 +97,14 @@ check_caretList_model_types <- function(list_of_models) {
   # Check that the model type is VALID
   stopifnot(all(types %in% c("Classification", "Regression")))
 
-  # Warn that we have not yet implemented multiclass models
-  # add a check that if this is null you did not set savePredictions in the trainControl
+  # TODO: add a check that if this is null you didn't set savePredictions in the trainControl
   # TODO: add support for non-prob models (e.g. rFerns)
+  # TODO: Check for ANY models having nulls
   if (type == "Classification") {
     for (model in list_of_models) {
       unique_obs <- unique(model$pred$obs)
       if (is.null(unique_obs)) {
         stop("No predictions saved by train. Please re-run models with trainControl set with savePredictions = TRUE.")
-      }
-      if (length(unique_obs) != 2) {
-        stop("Not yet implemented for multiclass problems")
       }
     }
   }
@@ -321,6 +318,8 @@ makePredObsMatrix <- function(list_of_models) {
   if (type == "Classification") {
     # Determine the string name for the positive class
     positive <- levels(modelLibrary$obs)[getBinaryTargetLevel()]
+
+    # TODO: For multiclass, use ALL PROBS.  Currently this is JUST positive class probs!
 
     # Use the string name for the positive class determined above to select
     # predictions from base estimators as predictors for ensemble model

--- a/tests/testthat/test-helper_functions.R
+++ b/tests/testthat/test-helper_functions.R
@@ -29,7 +29,7 @@ test_that("No predictions generates an error", {
       trControl = trainControl(method = "cv", number = 2, savePredictions = "final", classProbs = TRUE)
     )
   )
-  expect_error(check_caretList_model_types(models_multi))
+  check_caretList_model_types(models_multi)
 
   suppressWarnings(
     models <- caretList(

--- a/tests/testthat/test-multiclass.R
+++ b/tests/testthat/test-multiclass.R
@@ -1,0 +1,28 @@
+#############################################################################
+context("caretList and caretStack work for multiclass problems")
+#############################################################################
+test_that("Multiclass caretList and caretStack", {
+  data(iris)
+  my_control <- caret::trainControl(
+    method = "boot",
+    number = 5,
+    savePredictions = "final",
+    classProbs = TRUE,
+    index = caret::createResample(iris$Species, 5)
+  )
+  model_list <- caretList(
+    x = iris[, -5],
+    y = iris[, 5],
+    trControl = my_control,
+    methodList = c("glmnet", "rpart")
+  )
+  ens <- caretStack(model_list, method = "rpart")
+
+  p_raw <- predict(ens, iris[, -5], type = "raw")
+  expect_is(p_raw, "factor")
+  expect_equal(length(p_raw), nrow(iris))
+
+  p <- predict(ens, iris[, -5], type = "prob")
+  expect_is(p, "numeric")
+  expect_equal(length(p), nrow(iris))
+})


### PR DESCRIPTION
rebased https://github.com/zachmayer/caretEnsemble/pull/191/ off main, seems good now!

Initial working version of multiclass ensembling.  Work to be done:
- [ ] predict.caretList return a matrix of probs, not a vector for the positive class.
- [ ] predict.caretStack return a matrix of probs, not a vector for the positive class.
- [ ] Internally, makePredObsMatrix just uses positive class probs.  Make it use ALL class probs so we can do proper ensembling.
- [ ] Fix the test to do a train/test split and make a confusion matrix
