### PR TITLE
Multiclass pr

### DIFF
--- a/R/caretStack.R
+++ b/R/caretStack.R
@@ -87,7 +87,7 @@ predict.caretStack <- function(
     if (getMulticlassExcludedLevel() >= 1 && getMulticlassExcludedLevel() <= num_classes) {
       classes_included <- levels(object$models[[1]]$pred$obs)[-getMulticlassExcludedLevel()]
     } else {
-      warning("Invalid option forcaret.ensemble.multiclass.excluded.level. Returning all classes.")
+      warning("Value for caret.ensemble.multiclass.excluded.level is outside the range between 1 and the number of classes. Returning all classes.")
       classes_included <- levels(object$models[[1]]$pred$obs)
     }
     pattern <- paste(classes_included, collapse = "|")

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -414,6 +414,7 @@ makePredObsMatrix <- function(list_of_models) {
     if (getMulticlassExcludedLevel() >= 1 && getMulticlassExcludedLevel() <= num_classes) {
       classes_included <- levels(list_of_models[[1]]$pred$obs)[-getMulticlassExcludedLevel()]
     } else {
+      warning("Value for caret.ensemble.multiclass.excluded.level is outside the range between 1 and the number of classes. Returning all classes.")
       classes_included <- levels(list_of_models[[1]]$pred$obs)
     }
     class_model_combinations <- expand.grid(classes_included, names(modelLibrary))

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -414,7 +414,7 @@ makePredObsMatrix <- function(list_of_models) {
     if (getMulticlassExcludedLevel() >= 1 && getMulticlassExcludedLevel() <= num_classes) {
       classes_included <- levels(list_of_models[[1]]$pred$obs)[-getMulticlassExcludedLevel()]
     } else {
-      warning("Value for caret.ensemble.multiclass.excluded.level is outside the range between 1 and the number of classes. Returning all classes.")
+      warning("Value for caret.ensemble.multiclass.excluded.level is outside the range between 1 and the number of classes. Using all classes to train meta-model.")
       classes_included <- levels(list_of_models[[1]]$pred$obs)
     }
     class_model_combinations <- expand.grid(classes_included, names(modelLibrary))

--- a/tests/testthat/test-caretStack.R
+++ b/tests/testthat/test-caretStack.R
@@ -168,7 +168,7 @@ test_that("predict.caretStack works correctly if the multiclass excluded level i
         trControl = trainControl(method = "cv")
       )
     },
-    "Value for caret.ensemble.multiclass.excluded.level is outside the range between 1 and the number of classes. Returning all classes."
+    "Value for caret.ensemble.multiclass.excluded.level is outside the range between 1 and the number of classes. Using all classes to train meta-model."
   )
   # Predict with the caretStack
   expect_warning(

--- a/tests/testthat/test-caretStack.R
+++ b/tests/testthat/test-caretStack.R
@@ -154,21 +154,28 @@ test_that("predict.caretStack works correctly if the multiclass excluded level i
     methodList = c("rpart", "rf")
   )
 
-  # Create a caretStack
-  meta_model <- caretStack(
-    model_list,
-    method = "rpart",
-    trControl = trainControl(method = "cv")
-  )
+
 
   # Make sure predictions still work if the exlcuded level is too high
   options(caret.ensemble.multiclass.excluded.level = 4L)
   expect_equal(getMulticlassExcludedLevel(), 4L)
+  # Create a caretStack
+  expect_warning(
+    {
+      meta_model <- caretStack(
+        model_list,
+        method = "rpart",
+        trControl = trainControl(method = "cv")
+      )
+    },
+    "Value for caret.ensemble.multiclass.excluded.level is outside the range between 1 and the number of classes. Returning all classes."
+  )
+  # Predict with the caretStack
   expect_warning(
     {
       pred <- predict(meta_model, newdata = iris, type = "prob")
     },
-    "Invalid option forcaret.ensemble.multiclass.excluded.level. Returning all classes."
+    "Value for caret.ensemble.multiclass.excluded.level is outside the range between 1 and the number of classes. Returning all classes."
   )
   options(caret.ensemble.multiclass.excluded.level = 1L)
   expect_equal(nrow(pred), 150)


### PR DESCRIPTION
This pull request includes 2 changes associated with option `caret.ensemble.multiclass.excluded.level`:

- [x] Included a warning message when function `makePredObsMatrix` is called inside of `train.caretStack` and the value of the option `caret.ensemble.multiclass.excluded.level` is outside of the range between 1 and the number of the classes.
- [x] Changed the warning message to match the documentation of the function `setMulticlassExcludedLevel`.