### PR TITLE
Add tests to check that the character | is not allowed in variable na…

### DIFF
--- a/tests/testthat/test-caretList.R
+++ b/tests/testthat/test-caretList.R
@@ -173,9 +173,9 @@ test_that("as.caretList.list returns a caretList object", {
 
 
 #############################################################
-context("Bad characters in variable names and model names")
+context("Bad characters in target variable names and model names")
 #############################################################
-test_that("Variable names with character | are not allowed", {
+test_that("Target variable names with character | are not allowed", {
   bad_iris <- iris[1:100, ]
   bad_iris[, 5] <- gsub("versicolor", "versicolor|1", bad_iris[, 5])
   bad_iris[, 5] <- gsub("setosa", "setosa|2", bad_iris[, 5])


### PR DESCRIPTION
This PR adds 2 tests:

- The first one checks that an error is raised by caret when the train.caretList function is called and any target variable name contains the character "|". For example, in the iris dataset, the test checks that the following target variable names are not valid: c("seto|sa", "virgini|ca", "ver|sicolor").
- The second one checks that if the character "|" is included in any specified model name in a caretList, this model name is renamed changing the character "|" to ".". For example, "nnet|1" is changed to "nnet.1".

These tests are necessary because the predict.caretStack function requires that neither the target variable names nor the model names contain the character "|".