### PR TITLE
Fix lint CI: install lint deps from CRAN, stop scraping GitHub (429)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,10 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: local::.
-
-      - name: Install
-        run: make install
+          extra-packages: any::lintr, any::spelling, any::devtools, local::.
 
       - name: Lint
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,6 @@ install-deps:
 	Rscript -e "devtools::install_deps()"
 	Rscript -e "devtools::install_dev_deps()"
 	Rscript -e "devtools::update_packages()"
-	Rscript -e "devtools::install_github('r-lib/lintr')"
 	Rscript -e "devtools::install_github('r-lib/revdepcheck')"
 
 .PHONY: install


### PR DESCRIPTION
## Problem

The `lint` job fails on every open PR (#401, #404, #405) because it runs `make install`, whose `install-deps` target uses `devtools::install_github()` for **lintr** and **revdepcheck**. `install_github` downloads by scraping GitHub, which gets throttled:

```
Failed to install ... from GitHub: HTTP error 429 (temporarily throttled)
Rate limit remaining: 5000/5000
```

The API rate limit is untouched (5000/5000), so a PAT does **not** help.

## Fix

The lint job only needs **lintr** + **spelling** — both on CRAN. `revdepcheck` is reverse-dependency tooling for the release flow (`check-rev-dep`, `recheck.yml`), irrelevant to linting.

- `lint.yaml`: install `lintr`, `spelling`, `devtools` via `setup-r-dependencies` (RSPM binaries) and run `make lint` / `make spell` directly — no more `make install`, no GitHub scraping, and faster.
- `Makefile`: drop the redundant `install_github('r-lib/lintr')` dev override (lintr is already in Suggests, so `install_dev_deps()` pulls the CRAN release).

The release/revdep flow (`revdepcheck` in `install-deps`, `check-rev-dep`, `recheck.yml`) is untouched.

Closes the CI blocker on #401, #404, #405.