### PR TITLE
Build-ignore Claude Code artifacts in .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,6 +3,8 @@ project-tree.txt
 .aider.chat.history.md
 .aider.input.history
 .aider.tags.cache.v3
+^\.claude$
+^CLAUDE\.md$
 coverage.rds
 coverage-report.html
 cobertura.xml


### PR DESCRIPTION
Adds `.claude` (the local Claude Code settings dir) and `CLAUDE.md` to `.Rbuildignore`, alongside the existing `.aider.*` / `.openhands_instructions` / `.coderabbit.yaml` entries.

**Why:** these are AI-tool dotfiles, not package contents. Without ignoring `.claude`, a local `R CMD check` (or a CRAN-submission build) raises:
```
checking for hidden files and directories ... NOTE
Found the following hidden files and directories: .claude
```
They're untracked, so CI's clean checkout never saw this — but a **local pre-CRAN build would**, and the last CRAN submission predated Claude Code. With `error_on='note'` that NOTE is a hard failure, so this keeps local checks clean.