### PR TITLE
Guard array/matrix test against missing Suggests (fixes CRAN klaR ERROR)

### DIFF
--- a/tests/testthat/test-caretList.R
+++ b/tests/testthat/test-caretList.R
@@ -293,6 +293,10 @@ testthat::test_that("caretList supports custom models", {
 })
 
 testthat::test_that("caretList supports models that return an array or matrix", {
+  # These models come from Suggests; skip if unavailable (e.g. a CRAN flavor
+  # where klaR can't be installed) so the check NOTEs/skips instead of erroring.
+  testthat::skip_if_not_installed("earth")
+  testthat::skip_if_not_installed("klaR")
   set.seed(42L)
   nrows <- 100L
   ncols <- 2L


### PR DESCRIPTION
## Problem
The current CRAN check fails:
```
test-caretList.R:309 ... Error: Required packages are missing: klaR
```
The test "caretList supports models that return an array or matrix" fits `earth + gam + stepLDA`. `stepLDA` needs **klaR** (a Suggests dep), but the test has no skip guard — so on any CRAN flavor where klaR can't be installed, `caret::checkInstall` **errors** and fails the check.

## Fix
Add `testthat::skip_if_not_installed()` for **earth** and **klaR** — the two Suggests-only deps this test uses (`mgcv` for gam and `MASS` for stepLDA are recommended packages, always present). The test now skips gracefully when a Suggests dep is unavailable instead of erroring — the standard CRAN pattern for conditional Suggests use. Full coverage is retained wherever klaR is installed.

## Note
This is the only test that tripped, but the suite has **no** `skip_if_not_installed` guards anywhere — other Suggests-dependent tests (earth/gam/gbm/glmnet/…) share the same latent risk if any ever goes missing on a flavor. A broader guard pass is worth considering, but this fixes the live failure.