### PR TITLE
Restore PDF manual on R-devel with full TeX Live in monthly check

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {r: 'devel', http-user-agent: 'release', manual: 'FALSE'}
+          - {r: 'devel', http-user-agent: 'release'}
           - {r: 'release'}
           - {r: 'oldrel-1'}
           - {r: 'oldrel-2'}
@@ -33,10 +33,9 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
       - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
-      - uses: r-lib/actions/setup-tinytex@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
-      - run: sudo apt update && sudo apt install tidy
+      # Full TeX Live (not TinyTeX) so the PDF manual builds with every LaTeX
+      # package already present -- no on-demand tlmgr installs to flake on
+      # R-devel around the spring TeX Live rollover. MANUAL defaults to TRUE in
+      # the Makefile, so every R version (devel included) builds the manual.
+      - run: sudo apt-get update && sudo apt-get install -y tidy texlive-full
       - run: make check
-        env:
-          # Skip the PDF manual on R-devel only: it fails on R-devel's flaky
-          # LaTeX toolchain, not on package problems. Defaults to TRUE elsewhere.
-          MANUAL: ${{ matrix.config.manual || 'TRUE' }}


### PR DESCRIPTION
## What

Restore the PDF reference-manual build on **R-devel** in the monthly check, and install the full TeX Live (`texlive-full`) instead of on-demand TinyTeX. Reverts the R-devel `manual: 'FALSE'` from #401.

## Why

#401 muted the devel manual because it failed intermittently (Feb ✓, Mar ✗, Apr ✗, May ✓, Jun ✗) while `release` + all three `oldrel`s rendered the same PDF fine in the same run. That correctly ruled out a package / `.Rd` defect — but muting the check throws away R-devel's value as an early-warning canary for future R releases.

## Root-cause hypothesis

The most recent failed run ([26729275350](https://github.com/zachmayer/caretEnsemble/actions/runs/26729275350)) has **no specific LaTeX error** — just an empty *"LaTeX errors found:"*. So there is no smoking gun in the log. But the failures cluster in **March + April**, exactly the annual TeX Live rollover — the fingerprint of TinyTeX's **on-demand** `tlmgr` installs flaking while the package repo is mid-release (the same 2025→2026 cross-release wall that currently blocks local installs).

`texlive-full` pre-installs every LaTeX package, so there are **no on-demand installs to flake**. This de-confounds the signal:

- If R-devel now builds the manual reliably → it was LaTeX-package flakiness (fixed).
- If it still fails → that is R-devel's own `Rd2pdf` (release + oldrel pass with their own TinyTeX in the same run), which is a **real** early warning worth investigating — and the log should now surface a specific error to chase.

Either way, R-devel becomes a manual signal you can trust instead of noise you learn to ignore.

## Validation

Dispatch on this branch: **Actions → Monthly Ubuntu R CMD Check → Run workflow → branch `restore-devel-pdf-manual`** (or `gh workflow run monthly.yml --ref restore-devel-pdf-manual`). Intermittency means it may take a couple of runs to trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
